### PR TITLE
[feat] dynamic indexed memref slice

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1064,20 +1064,22 @@ class ASTTransformer(ASTBuilder):
         return None
 
     @staticmethod
-    def build_slices(ctx: ASTContext, node: ast.Subscript, in_shape: ShapedType):
+    def build_slices(ctx: ASTContext, node: ast.Subscript, in_shape: list[int]):
+        # TODO: support dynamic.
         # calculate the static offsets, sizes, strides for ExtractSlice and InsertSlice
         if isinstance(node.slice, ast.Tuple):
             slices = list(node.slice.elts)
         else:
             slices = node.slice.dims if len(node.shape) > 1 else [node.slice]
+        offsets = []
+        sizes = []
+        strides = []
         static_offsets = []
         static_sizes = []
         static_strides = []
-        offsets = []
-        sizes = []
-        # Not support dynamic strides?
         for index, size in zip(slices, in_shape):
             if isinstance(index, ast.Slice):
+                # fixme: slice lower/upper/step is not constant
                 lower = (
                     0
                     if index.lower is None
@@ -1097,10 +1099,6 @@ class ASTTransformer(ASTBuilder):
                 if lower is None:
                     static_offsets.append(ShapedType.get_dynamic_size())
                     offset_expr = build_stmt(ctx, index.lower)
-                    offset = ASTTransformer.build_cast_op(
-                        ctx, offset_expr, index.dtype, Index()
-                    ).result
-                    offsets.append(offset)
                     static_sizes.append(ShapedType.get_dynamic_size())
                     if upper is None:
                         upper_expr = build_stmt(ctx, index.upper)
@@ -1114,7 +1112,6 @@ class ASTTransformer(ASTBuilder):
                     size = ASTTransformer.build_cast_op(
                         ctx, size_expr, index.dtype, Index()
                     ).result
-                    sizes.append(size)
                     continue
                 if upper is None:
                     static_sizes.append(ShapedType.get_dynamic_size())
@@ -1125,26 +1122,51 @@ class ASTTransformer(ASTBuilder):
                     size = ASTTransformer.build_cast_op(
                         ctx, size_expr, index.dtype, Index()
                     ).result
-                    sizes.append(size)
                     continue
+                if lower < 0 or upper < 0:
+                    raise RuntimeError("Unsupported negative index")
+                if lower >= size or upper > size:
+                    raise RuntimeError("Index out of range")
+                if step <= 0:
+                    raise RuntimeError("Unsupported negative step")
+                if step > upper - lower:
+                    raise RuntimeError("Step larger than range")
+                static_offsets.append(lower)
+                static_sizes.append((upper - lower) // step)
+                static_strides.append(step)
             elif isinstance(index, (ast.Index, ast.Constant)):
                 lower = (
                     index.value.value if isinstance(index, ast.Index) else index.value
                 )
-                upper = lower + 1
-                step = 1
-            if lower < 0 or upper < 0:
-                raise RuntimeError("Unsupported negative index")
-            if lower > size or upper > size:
-                raise RuntimeError("Index out of range")
-            if step <= 0:
-                raise RuntimeError("Unsupported negative step")
-            if step > upper - lower:
-                raise RuntimeError("Step larger than range")
-            static_offsets.append(lower)
-            static_sizes.append((upper - lower) // step)
-            static_strides.append(step)
-        return static_offsets, static_sizes, static_strides
+                if lower < 0:
+                    raise RuntimeError("Unsupported negative index")
+                if lower >= size:
+                    raise RuntimeError("Index out of range")
+                static_offsets.append(lower)
+                static_sizes.append(1)
+                static_strides.append(1)
+                continue
+            elif isinstance(index, ast.Name):
+                index = build_stmt(ctx, index)
+                if isinstance(index, MockConstant):
+                    lower = index.val
+                    if lower < 0:
+                        raise RuntimeError("Unsupported negative index")
+                    if lower >= size:
+                        raise RuntimeError("Index out of range")
+                    static_offsets.append(lower)
+                    static_sizes.append(1)
+                    static_strides.append(1)
+                    continue
+                # fixme: unverified
+                offsets.append(index)
+                static_offsets.append(-1)
+                static_sizes.append(1)
+                static_strides.append(1)
+                continue
+            else:
+                raise ValueError(f"Unsupported slice index type ({type(index)})")
+        return offsets, sizes, strides, static_offsets, static_sizes, static_strides
 
     @staticmethod
     def build_tensor_access(
@@ -1156,6 +1178,9 @@ class ASTTransformer(ASTBuilder):
             dtype = RankedTensorType(value.result.type).element_type
             in_shape = RankedTensorType(value.result.type).shape
             (
+                offsets,
+                sizes,
+                strides,
                 static_offsets,
                 static_sizes,
                 static_strides,
@@ -1169,9 +1194,9 @@ class ASTTransformer(ASTBuilder):
                     static_sizes=static_sizes,
                     static_strides=static_strides,
                     static_offsets=static_offsets,
-                    offsets=[],
-                    sizes=[],
-                    strides=[],
+                    offsets=offsets,
+                    sizes=sizes,
+                    strides=strides,
                     ip=ctx.get_ip(),
                 )
             else:  # ast.Store
@@ -1216,6 +1241,9 @@ class ASTTransformer(ASTBuilder):
             dtype = MemRefType(value.result.type).element_type
             in_shape = MemRefType(value.result.type).shape
             (
+                offsets,
+                sizes,
+                strides,
                 static_offsets,
                 static_sizes,
                 static_strides,
@@ -1242,21 +1270,31 @@ class ASTTransformer(ASTBuilder):
             new_strides = [
                 orig_strides[i] * static_strides[i] for i in range(len(static_strides))
             ]
-            layout = StridedLayoutAttr.get(new_offset, new_strides)
-            result = MemRefType.get(static_sizes, dtype, layout=layout)
+            result_strides = []
+            result_sizes = []
+            for idx_, size in enumerate(static_sizes):
+                if size > 1:
+                    result_sizes.append(size)
+                    result_strides.append(new_strides[idx_])
+            layout = StridedLayoutAttr.get(new_offset, result_strides)
+            result = MemRefType.get(result_sizes, dtype, layout=layout)
             subview = memref_d.SubViewOp(
                 source=value.result,
                 result=result,
                 static_offsets=static_offsets,
                 static_sizes=static_sizes,
                 static_strides=static_strides,
-                offsets=[],
-                sizes=[],
-                strides=[],
+                offsets=offsets,
+                sizes=sizes,
+                strides=strides,
                 ip=ctx.get_ip(),
             )
             if isinstance(node.ctx, ast.Load):
-                op = subview
+                # copy to another memref type to avoid some annoying type compatibility issue
+                memref_type = MemRefType.get(result_sizes, dtype)
+                alloc_op = memref_d.AllocOp(memref_type, [], [], ip=ctx.get_ip())
+                memref_d.CopyOp(subview.result, alloc_op.result, ip=ctx.get_ip())
+                op = alloc_op
             else:
                 op = memref_d.CopyOp(val.result, subview.result, ip=ctx.get_ip())
         else:
@@ -1313,6 +1351,12 @@ class ASTTransformer(ASTBuilder):
                 )
                 # pylint: disable=redefined-variable-type
                 op = subview
+                if isinstance(node.ctx, ast.Load):
+                    # copy to another memref type to avoid some annoying type compatibility issue
+                    memref_type = MemRefType.get(node.shape, node.dtype.build())
+                    alloc_op = memref_d.AllocOp(memref_type, [], [], ip=ctx.get_ip())
+                    memref_d.CopyOp(subview.result, alloc_op.result, ip=ctx.get_ip())
+                    op = alloc_op
             elif is_affine:
                 affine_map = AffineMap.get(
                     dim_count=ctx.dim_count, symbol_count=0, exprs=new_indices

--- a/mlir/lib/Transforms/CopyOnWrite.cpp
+++ b/mlir/lib/Transforms/CopyOnWrite.cpp
@@ -37,6 +37,13 @@ void removeRedundantCopy(func::FuncOp &func) {
     // llvm::errs() << *op << "\n";
     auto src = op->getOperand(0);
     auto dst = op->getOperand(1);
+
+    auto srcType = src.getType().dyn_cast<MemRefType>();
+    auto dstType = dst.getType().dyn_cast<MemRefType>();
+    if (!srcType || !dstType || srcType != dstType) {
+      continue;
+    }
+
     bool resolvable = true;
     Operation *last_user = getLastUse(src, *func);
 

--- a/tests/dataflow/aie/test_mapping_gemm.py
+++ b/tests/dataflow/aie/test_mapping_gemm.py
@@ -499,6 +499,59 @@ def _test_split_k_gemm_2x2x4():
     print("PASSED!")
 
 
+def _test_split_k_explicit_gather_gemm_1x1x4():
+
+    Ty = int16
+    M, N, K = 32, 32, 64
+    Pk = 4
+
+    LyA = Layout("RS0")
+    LyB = Layout("S0R")
+
+    @df.region()
+    def top():
+        pipe = df.array(df.pipe(dtype=Ty, shape=(M, N), depth=2), shape=(Pk,))
+
+        @df.kernel(mapping=[Pk])
+        def partial_gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB):
+            pk = df.get_pid()
+            pipe[pk].put(allo.matmul(A, B))
+
+        @df.kernel(mapping=[1])
+        def acc(C: Ty[M, N]):
+            C_: Ty[M, N] = 0
+            # gather
+            buffer: Ty[Pk, M, N]
+            with allo.meta_for(Pk) as i:
+                buffer[i, :, :] = pipe[i].get()
+            # accumulate
+            for i in range(Pk):
+                C_[:, :] += buffer[i]
+            C[:, :] = C_
+
+    mod = df.build(
+        top,
+        target="aie",
+        mapping_primitives=[
+            (
+                "bundle",
+                [
+                    "partial_gemm_0",
+                    "partial_gemm_1",
+                    "partial_gemm_2",
+                    "partial_gemm_3",
+                ],
+            ),
+        ],
+    )
+    A = np.random.randint(0, 64, (M, K)).astype(np.int16)
+    B = np.random.randint(0, 64, (K, N)).astype(np.int16)
+    C = np.zeros((M, N)).astype(np.int16)
+    mod(A, B, C)
+    np.testing.assert_allclose(C, A @ B, atol=1e-5)
+    print("PASSED!")
+
+
 if __name__ == "__main__":
     _test_gemm_2D_v1()
     _test_gemm_2D_v2()
@@ -509,3 +562,4 @@ if __name__ == "__main__":
     _test_pingpong_gemm_4x4x4()
     _test_split_k_gemm_1x1x4()
     _test_split_k_gemm_2x2x4()
+    _test_split_k_explicit_gather_gemm_1x1x4()


### PR DESCRIPTION
Partially fixed [this issue](https://github.com/cornell-zhang/allo/issues/425).

A working example
```python
    Ty = int16
    M, N, K = 32, 32, 64
    Pk = 4

    LyA = Layout("RS0")
    LyB = Layout("S0R")

    @df.region()
    def top():
        pipe = df.array(df.pipe(dtype=Ty, shape=(M, N), depth=2), shape=(Pk,))

        @df.kernel(mapping=[Pk])
        def partial_gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB):
            pk = df.get_pid()
            pipe[pk].put(allo.matmul(A, B))

        @df.kernel(mapping=[1])
        def acc(C: Ty[M, N]):
            C_: Ty[M, N] = 0
            # gather
            buffer: Ty[Pk, M, N]
            with allo.meta_for(Pk) as i:
                buffer[i, :, :] = pipe[i].get()
            # accumulate
            for i in range(Pk):
                C_[:, :] += buffer[i]
            C[:, :] = C_

```