### PR TITLE
[Fix][Codegen][AIE] Revert Problematic Optimization on Stream Operations

### DIFF
--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -373,57 +373,9 @@ class CodeGenerator:
                                 if isinstance(fifo, tuple):
                                     fifo = fifo[0 if is_put else 1]
                                 if is_put:
-                                    if (
-                                        getattr(op, "name", None) == "memref.copy"
-                                        and len(list(op.operands[1].uses)) == 1
-                                    ):
-                                        alloc_op = op.operands[0].owner
-                                        # put once
-                                        if (
-                                            getattr(alloc_op, "name", None)
-                                            == "memref.alloc"
-                                        ):
-                                            uses = list(op.operands[0].uses)
-                                            with aie_ir.InsertionPoint(alloc_op):
-                                                acquired = fifo.acquire(0, 1)
-                                            for use in uses:
-                                                for i, v in enumerate(
-                                                    use.owner.operands
-                                                ):
-                                                    if (
-                                                        v.type == alloc_op.result.type
-                                                        and v == alloc_op.result
-                                                    ):
-                                                        use.owner.operands[i] = acquired
-                                            with aie_ir.InsertionPoint.at_block_terminator(
-                                                alloc_op.parent.regions[0].blocks[0]
-                                            ):
-                                                fifo.release(0, 1)
-                                            op.erase()
-                                            alloc_op.erase()
-                                            continue
                                     op.operands[1] = fifo.acquire(0, 1)
                                     new_op = op.clone()  # no use, no need to replace
                                     fifo.release(0, 1)
-                                elif is_tensor and len(list(op.operands[0].uses)) == 1:
-                                    # an optimize to reduce memref.copy
-                                    # get once
-                                    replaced = op.operands[1]
-                                    uses = list(replaced.uses)
-                                    with aie_ir.InsertionPoint(op):
-                                        acquired = fifo.acquire(1, 1)
-                                    for use in uses:
-                                        for i, v in enumerate(use.owner.operands):
-                                            if (
-                                                v.type == replaced.type
-                                                and v == replaced
-                                            ):
-                                                use.owner.operands[i] = acquired
-
-                                    with aie_ir.InsertionPoint.at_block_terminator(
-                                        op.parent.regions[0].blocks[0]
-                                    ):
-                                        fifo.release(1, 1)
                                 else:
                                     acquired = fifo.acquire(1, 1)
                                     op.operands[0] = acquired

--- a/tests/dataflow/aie/test_mapping_atb.py
+++ b/tests/dataflow/aie/test_mapping_atb.py
@@ -1,0 +1,74 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import allo
+import allo.dataflow as df
+from allo.backend.aie import is_available
+from allo.ir.types import int16, Stream
+import numpy as np
+
+Ty = int16
+M, N, K = 64, 16, 16
+RHO_VALUES = [1, 2, 4, 8]  # Change rho value here
+
+
+def make_atb_top(rho):
+    assert M % rho == 0
+    Ma = M // rho
+
+    @df.region()
+    def top(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
+        pipe_a: Stream[Ty[Ma, K], 2][rho]
+        pipe_b: Stream[Ty[K, N], 2][rho]
+        pipe_c: Stream[Ty[Ma, N], 2][rho]
+
+        @df.kernel(mapping=[1], args=[A])
+        def load_a(local_A: Ty[M, K]):
+            with allo.meta_for(rho) as i:
+                pipe_a[i].put(local_A[i * Ma : (i + 1) * Ma, :])
+
+        @df.kernel(mapping=[1], args=[B])
+        def load_b(local_B: Ty[K, N]):
+            with allo.meta_for(rho) as i:
+                pipe_b[i].put(local_B)
+
+        @df.kernel(mapping=[rho])
+        def compute():
+            pk = df.get_pid()
+            local_A: Ty[Ma, K] = pipe_a[pk].get()
+            local_B: Ty[K, N] = pipe_b[pk].get()
+            pipe_c[pk].put(allo.matmul(local_A, local_B))
+
+        @df.kernel(mapping=[1], args=[C])
+        def store_c(local_C: Ty[M, N]):
+            with allo.meta_for(rho) as i:
+                local_C[i * Ma : (i + 1) * Ma, :] = pipe_c[i].get()
+
+    return top
+
+
+def run_atb(rho):
+    top = make_atb_top(rho)
+    mapping_primitives = None
+    if rho > 1:
+        mapping_primitives = [("bundle", [f"compute_{i}" for i in range(rho)])]
+
+    A = np.random.randint(0, 64, (M, K)).astype(np.int16)
+    B = np.random.randint(0, 64, (K, N)).astype(np.int16)
+    C = np.zeros((M, N)).astype(np.int16)
+
+    if is_available():
+        os.environ["FORCE_UNROLL_INDEX"] = "1"
+        mod = df.build(top, target="aie", mapping_primitives=mapping_primitives)
+        mod(A, B, C)
+        del os.environ["FORCE_UNROLL_INDEX"]
+        np.testing.assert_allclose(C, A @ B, atol=1e-5)
+        print(f"rho={rho} PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+
+if __name__ == "__main__":
+    for rho in RHO_VALUES:
+        run_atb(rho)


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR partially fixes cornell-zhang#601.

TODO:
- [ ] clean up the stream operation lowering logic.
- [ ] fix the optimization

### Problems ###
Previous optimization on stream operation lowering is too aggressive and didn't consider inter-compute-tile fifo reuse.  The leads to the bug mentioned in cornell-zhang#601.


### Proposed Solutions ###
The problematic optimization is temporary disabled. **(will lead to some performance degradation)**


## Checklist ##

Please make sure to review and check all of these items:
- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
